### PR TITLE
Fix trinidad component name

### DIFF
--- a/src/FileView.js
+++ b/src/FileView.js
@@ -19,7 +19,7 @@ const FileView = ({ harJson }) => {
   const beginning = +new Date(harJson.log.pages[0].startedDateTime);
   let entries = harJson.log.entries.map(entry => {
     const desc = (entry.response.content.text.match(
-      /\.modules\.indexOf\("(.*?)"\)/
+      /\.modules\.indexOf\("((\/[^\/\)]*){3})/
     ) || entry.request.url.match(/^https?:\/\/[^\/]*\/([^ ?]*)/))[1]
       .replace(/-/g, "‑")
       .replace(/[a-z0-9]{40}/, "GUID");


### PR DESCRIPTION
Before it just used the file that happened to be first in the "package":

![image](https://user-images.githubusercontent.com/249764/54273520-5970a700-4586-11e9-9451-b1b9afe8c3f9.png)

Fix to use just the trinidad component part of the name:

![image](https://user-images.githubusercontent.com/249764/54273431-28907200-4586-11e9-9356-bf1c6835014c.png)
